### PR TITLE
Fix: require cmake 3.12.4 or above

### DIFF
--- a/fastmine/CMakeLists.txt
+++ b/fastmine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12.4)
 
 project(fastmine LANGUAGES CXX C)
 

--- a/fastmine/crypto/CMakeLists.txt
+++ b/fastmine/crypto/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2017-2019 The Bitcoin developers
+cmake_minimum_required(VERSION 3.12.4)
 
 project(crypto)
 


### PR DESCRIPTION
This is because the CMakeLists.txt we imported from bitcoind uses newer
cmake syntax, etc.  This enforces that requirement.  This should be new
enough for the docker build which uses cmake 3.13.x.

Unless you can figure out how to get this to work on cmake 3.10.. this patch is needed.

Note that Ubuntu 18.04 uses 3.10.x, but Ubuntu 18.10 or newer and our docker uses cmake 3.13.x+. *shrug*